### PR TITLE
Resolve Payload JSON Error

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,14 @@ let config;
 
 function getHeaders(method, resource, payload) {
   return {
-    'Authorization': HmacAuthorize.sign(method, resource, 'application/json',
-      payload ? JSON.stringify(payload) : null),
+    'Authorization': HmacAuthorize.sign(
+      method,
+      resource,
+      'application/json',
+      payload ? JSON.stringify(payload) : null
+    ),
     'User-Agent': 'ClassyPay Node.JS',
-    'Content-Type': 'application/json'
+    'Content-Type': payload ? 'application/json' : undefined
   };
 }
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ function getHeaders(method, resource, payload) {
   return {
     'Authorization': HmacAuthorize.sign(method, resource, 'application/json',
       payload ? JSON.stringify(payload) : null),
-    'User-Agent': 'ClassyPay Node.JS'
+    'User-Agent': 'ClassyPay Node.JS',
+    'Content-Type': 'application/json'
   };
 }
 
@@ -26,8 +27,7 @@ function getOptions(appId, method, resource, payload, pagination) {
     method,
     url: `${config.apiUrl}${resource}`,
     qs: getQs(appId, pagination),
-    json: payload !== null,
-    body: payload,
+    body: payload ? JSON.stringify(payload) : null,
     timeout: config.timeout,
     headers: getHeaders(method, resource, payload)
   };


### PR DESCRIPTION
This PR removes the `json: true` flag from the request options, and instead parses the payload and adds `'Content-Type': 'application/json'` to request headers.
This resolves the error that was causing any requests with a body to error: https://github.com/classy-org/classy-pay-client/issues/6