### PR TITLE
Support Custom Query Params

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Simple client for Classy Pay.
 
 # usage
 
-PayClient.request(appId, method, resource, postBody, callback)
+PayClient.request(appId, method, resource, payload, params, callback)
 
 ```javascript
 const PayClient = require('classy-pay-client')({
@@ -24,5 +24,14 @@ PayClient.get(0, '/transaction/1', (error, result) => {
     console.log(result);
   }
 });
+
+PayClient.request(0, 'GET', '/transaction/1', null, null, (error, result) => {
+  if (error) {
+    console.log(error);
+  } else {
+    console.log(result);
+  }
+});
+
 
 ```

--- a/index.js
+++ b/index.js
@@ -12,20 +12,19 @@ function getHeaders(method, resource, payload) {
   };
 }
 
-function getQs(appId, pagination) {
+function getQs(appId, params = {}) {
   return {
     appId,
     meta: true,
-    limit: pagination ? pagination.limit : undefined,
-    offset: pagination ? pagination.offset : undefined
+    ...params
   };
 }
 
-function getOptions(appId, method, resource, payload, pagination) {
+function getOptions(appId, method, resource, payload, params) {
   return {
     method,
     url: `${config.apiUrl}${resource}`,
-    qs: getQs(appId, pagination),
+    qs: getQs(appId, params),
     json: payload !== null,
     body: payload,
     timeout: config.timeout,
@@ -45,8 +44,8 @@ function getResult(error, response, body) {
   };
 }
 
-function request(appId, method, resource, payload, pagination, callback) {
-  let options = getOptions(appId, method, resource, payload, pagination);
+function request(appId, method, resource, payload, params, callback) {
+  let options = getOptions(appId, method, resource, payload, params);
   req(options, function(error, response, body) {
     callback(error, getResult(error, response, body));
   });

--- a/index.js
+++ b/index.js
@@ -15,12 +15,11 @@ function getHeaders(context, method, resource, payload) {
   };
 }
 
-function getQs(appId, params = {}) {
-  return {
+function getQs(appId, params) {
+  return _.extend({
     appId,
     meta: true,
-    ...params
-  };
+  }, params);
 }
 
 function getOptions(context, appId, method, resource, payload, params) {


### PR DESCRIPTION
This PR adds changes to Classy Pay Client's request function to support custom query params, in addition to the `limit` and `offset` pagination query params. Any query params passed will now be accepted and applied to a request.

#9 